### PR TITLE
Fix on GVim

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -85,7 +85,9 @@ command! SourceLocalVimrcOnce
     \ | call LVRWithCache('LVRRecurseUp', [getcwd(), s:c.names] )
     \ | endif
 
-SourceLocalVimrcOnce
+augroup localVimrc
+  au VimEnter * SourceLocalVimrcOnce
+augroup END
 
 " if its you writing a file update hash automatically
 fun! LVRUpdateCache(cache)


### PR DESCRIPTION
I found that this plugin doesn't work on GVim:
The popup to ask whether to source local .vimrc or not is shown, but gives no option except clicking the 'OK' button. And it never source-s the local .vimrc

I googled to find a problem very similar to this: http://stackoverflow.com/questions/20803199/strange-behavior-of-confirm-dialog-in-gvim

So I changed to execute SouceLocalVimrcOnce to read on VimEnter event
